### PR TITLE
feat: add link command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `completions` command to generate shell completions
 - support multiple files provided to `add` and `forget` commands
 - a `cd` command that spawns subshell at the puff's projects directory - user can backup the files
+- `link` command to create bring puff-managed files into other directories than the main project directory (useful for git
+  worktrees, jj workspaces, or any secondary working copy)
 - e2e tests
 
 ### Changed

--- a/src/cli_args.rs
+++ b/src/cli_args.rs
@@ -67,6 +67,13 @@ pub enum Command {
         subcommand: ProjectSubcommand,
     },
 
+    /// Creates symlinks for a project's managed files in the current directory.
+    /// Useful for git worktrees, jj workspaces, or any secondary working copy.
+    Link {
+        /// The project to link
+        project_name: String,
+    },
+
     /// Opens a new shell in the puff data directory where managed files are stored.
     /// Use --print to just print the path instead.
     Cd {

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -2,6 +2,7 @@ pub mod add_command;
 pub mod cd_command;
 pub mod file_forget_command;
 pub mod init_command;
+pub mod link_command;
 pub mod list_command;
 pub mod project_forget_command;
 pub mod status_command;

--- a/src/commands/link_command.rs
+++ b/src/commands/link_command.rs
@@ -1,0 +1,67 @@
+use anyhow::{Result, bail};
+use std::{fs, path::Path};
+
+use crate::{
+    config::{
+        locations::LocationsProvider,
+        projects::{ProjectDetails, ProjectsRetriever},
+    },
+    project_init::existing::create_symlinks_for_managed_files,
+};
+
+pub struct LinkCommand<'a> {
+    projects_retriever: &'a ProjectsRetriever<'a>,
+    locations_provider: &'a LocationsProvider,
+}
+
+impl<'a> LinkCommand<'a> {
+    pub fn new(
+        projects_retriever: &'a ProjectsRetriever<'a>,
+        locations_provider: &'a LocationsProvider,
+    ) -> Self {
+        LinkCommand {
+            projects_retriever,
+            locations_provider,
+        }
+    }
+
+    pub fn link(&self, project_name: &str, cwd: &Path) -> Result<()> {
+        let details = self.projects_retriever.get_details(project_name)?;
+
+        let associated = match details {
+            None => bail!(
+                "Project '{}' was not found. Check 'puff list' for available projects.",
+                project_name
+            ),
+            Some(ProjectDetails::Unassociated(_)) => bail!(
+                "Project '{}' is not associated with any directory on this machine. Run 'puff init' first.",
+                project_name
+            ),
+            Some(ProjectDetails::Associated(a)) => a,
+        };
+
+        if cwd == associated.user_dir
+            || fs::canonicalize(cwd).ok() == fs::canonicalize(&associated.user_dir).ok()
+        {
+            bail!("You're already in the project's main directory. Nothing to link.");
+        }
+
+        if associated.info.files.is_empty() {
+            println!("Project '{}' has no managed files.", project_name);
+            return Ok(());
+        }
+
+        let managed_dir = self.locations_provider.get_managed_dir(project_name);
+        create_symlinks_for_managed_files(cwd, &managed_dir)?;
+
+        let count = associated.info.files.len();
+        println!(
+            "Linked {} file{} from project '{}' into current directory.",
+            count,
+            if count == 1 { "" } else { "s" },
+            project_name
+        );
+
+        Ok(())
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@ use clap_complete::generate;
 use cli_args::{AppArgs, Command};
 use commands::{
     add_command::AddCommand, cd_command::CdCommand, file_forget_command::ForgetCommand,
-    init_command::InitCommand, list_command::ListCommand,
+    init_command::InitCommand, link_command::LinkCommand, list_command::ListCommand,
     project_forget_command::ProjectForgetCommand, status_command::StatusCommand,
 };
 use config::{
@@ -140,6 +140,12 @@ fn run() -> Result<()> {
                 )?;
             }
         },
+        Command::Link { project_name } => {
+            let cwd = env::current_dir()?;
+            let projects_retriever = ProjectsRetriever::new(app_config, &locations_provider);
+            let command = LinkCommand::new(&projects_retriever, &locations_provider);
+            command.link(&project_name, &cwd)?;
+        }
         // handled up above
         Command::Completions { .. } | Command::Cd { .. } => unreachable!(),
     }

--- a/src/project_init/existing.rs
+++ b/src/project_init/existing.rs
@@ -24,81 +24,72 @@ impl<'a> ExistingProjectInitializer<'a> {
 
         self.app_config_manager.add_project(name, user_dir)?;
 
-        self.bring_in_existing_secrets(name, user_dir, managed_dir)?;
+        create_symlinks_for_managed_files(user_dir, managed_dir)?;
 
         Ok(())
     }
 
-    /// Initializes the user's project directory with files managed by puff
-    fn bring_in_existing_secrets(
-        &self,
-        _project_name: &str,
-        user_dir: &Path,
-        managed_dir: &Path,
-    ) -> Result<()> {
-        self.process_managed_dir(user_dir, managed_dir, managed_dir)
-    }
+}
 
-    fn process_managed_dir(
-        &self,
-        user_dir: &Path,
-        managed_dir: &Path,
-        current_dir: &Path,
-    ) -> Result<()> {
-        for entry in current_dir.read_dir()? {
-            match entry {
-                Ok(entry) => {
-                    let path = entry.path();
-                    if path.is_dir() {
-                        self.process_managed_dir(user_dir, managed_dir, &path)?;
-                    } else {
-                        let relative_path = path.strip_prefix(managed_dir)?;
-                        self.handle_existing_file(&path, user_dir, relative_path)?;
-                    }
-                }
-                Err(_err) => {
-                    bail!(
-                        "The project already contains some files, but some of them could not be read"
-                    );
+/// Creates symlinks in `target_dir` for all files in `managed_dir`,
+/// preserving directory structure.
+pub fn create_symlinks_for_managed_files(target_dir: &Path, managed_dir: &Path) -> Result<()> {
+    walk_managed_dir(target_dir, managed_dir, managed_dir)
+}
+
+fn walk_managed_dir(target_dir: &Path, managed_dir: &Path, current_dir: &Path) -> Result<()> {
+    for entry in current_dir.read_dir()? {
+        match entry {
+            Ok(entry) => {
+                let path = entry.path();
+                if path.is_dir() {
+                    walk_managed_dir(target_dir, managed_dir, &path)?;
+                } else {
+                    let relative_path = path.strip_prefix(managed_dir)?;
+                    symlink_one_file(&path, target_dir, relative_path)?;
                 }
             }
+            Err(_err) => {
+                bail!(
+                    "The project already contains some files, but some of them could not be read"
+                );
+            }
         }
-        Ok(())
+    }
+    Ok(())
+}
+
+fn symlink_one_file(managed_file: &Path, target_dir: &Path, relative_path: &Path) -> Result<()> {
+    let managed_file_name = managed_file
+        .file_name()
+        .ok_or_else(|| anyhow!("Existing file {:?} could not be read", managed_file))?;
+
+    let file_in_target_dir = target_dir.join(relative_path);
+    fs::create_dir_all(file_in_target_dir.parent().unwrap())?;
+
+    if let Ok(target) = fs::read_link(&file_in_target_dir) {
+        if target == managed_file {
+            return Ok(());
+        }
     }
 
-    /// Sets up a single file managed by puff to be accessible in user's project
-    /// directory
-    fn handle_existing_file(
-        &self,
-        managed_file: &Path,
-        user_dir: &Path,
-        relative_path: &Path,
-    ) -> Result<()> {
-        let managed_file_name = managed_file
-            .file_name()
-            .ok_or_else(|| anyhow!("Existing file {:?} could not be read", managed_file))?;
-
-        let file_in_user_dir = user_dir.join(relative_path);
-        fs::create_dir_all(file_in_user_dir.parent().unwrap())?;
-
-        if file_in_user_dir.exists() {
-            let backup = backup_file(&file_in_user_dir)?;
-            fs::remove_file(&file_in_user_dir)?;
-            println!(
-                "Conflict: {:?} exists in both the project directory and puff's registry. \
-                A backup of the original file was created at {}. \
-                {:?} now points to the puff-managed version. \
-                Review the backup before committing.",
-                managed_file_name,
-                backup.unwrap(),
-                file_in_user_dir.file_name().unwrap()
-            );
-        }
-
-        symlink_file(managed_file, &file_in_user_dir)?;
-
-        Ok(())
+    if file_in_target_dir.exists() || file_in_target_dir.symlink_metadata().is_ok() {
+        let backup = backup_file(&file_in_target_dir)?;
+        fs::remove_file(&file_in_target_dir)?;
+        println!(
+            "Conflict: {:?} exists in both the project directory and puff's registry. \
+            A backup of the original file was created at {}. \
+            {:?} now points to the puff-managed version. \
+            Review the backup before committing.",
+            managed_file_name,
+            backup.unwrap(),
+            file_in_target_dir.file_name().unwrap()
+        );
     }
+
+    symlink_file(managed_file, &file_in_target_dir)?;
+
+    Ok(())
 }
 
 #[cfg(test)]

--- a/tests/e2e/link.bats
+++ b/tests/e2e/link.bats
@@ -1,0 +1,134 @@
+#!/usr/bin/env bats
+load helpers
+
+setup() { setup_puff_env; }
+teardown() { teardown_puff_env; }
+
+@test "link: creates symlinks in another directory" {
+  puff_init "myproject"
+  echo "secret=123" >.env
+  puff add .env
+
+  local other_dir
+  other_dir="$(mktemp -d)"
+  cd "$other_dir"
+  run puff link myproject
+  assert_success
+  assert_symlink "$other_dir/.env"
+  assert_file_content "$other_dir/.env" "secret=123"
+
+  rm -rf "$other_dir"
+}
+
+@test "link: file in subdirectory creates correct structure" {
+  puff_init "myproject"
+  mkdir -p config
+  echo "db=postgres://localhost" >config/database.env
+  puff add config/database.env
+
+  local other_dir
+  other_dir="$(mktemp -d)"
+  cd "$other_dir"
+  run puff link myproject
+  assert_success
+  assert_symlink "$other_dir/config/database.env"
+  assert_file_content "$other_dir/config/database.env" "db=postgres://localhost"
+
+  rm -rf "$other_dir"
+}
+
+@test "link: conflict creates backup and replaces with symlink" {
+  puff_init "myproject"
+  echo "managed=1" >.env
+  puff add .env
+
+  local other_dir
+  other_dir="$(mktemp -d)"
+  echo "local=2" >"$other_dir/.env"
+  cd "$other_dir"
+  run puff link myproject
+  assert_success
+  assert_symlink "$other_dir/.env"
+  assert_file_content "$other_dir/.env" "managed=1"
+  assert_file_exists "$other_dir/.env.bak"
+  assert_file_content "$other_dir/.env.bak" "local=2"
+
+  rm -rf "$other_dir"
+}
+
+@test "link: nonexistent project fails with error" {
+  local other_dir
+  other_dir="$(mktemp -d)"
+  cd "$other_dir"
+  run puff link no-such-project
+  assert_failure
+
+  rm -rf "$other_dir"
+}
+
+@test "link: from main directory fails with error" {
+  puff_init "myproject"
+  echo "secret=123" >.env
+  puff add .env
+
+  run puff link myproject
+  assert_failure
+  assert_output_contains "main directory"
+}
+
+@test "link: re-run picks up newly added files" {
+  puff_init "myproject"
+  echo "first=1" >.env
+  puff add .env
+
+  local other_dir
+  other_dir="$(mktemp -d)"
+  cd "$other_dir"
+  puff link myproject
+  assert_symlink "$other_dir/.env"
+
+  cd "$PROJECT_DIR"
+  echo "second=2" >.secrets
+  puff add .secrets
+
+  cd "$other_dir"
+  run puff link myproject
+  assert_success
+  assert_symlink "$other_dir/.env"
+  assert_symlink "$other_dir/.secrets"
+  assert_not_exists "$other_dir/.env.bak"
+
+  rm -rf "$other_dir"
+}
+
+@test "link: project with no managed files prints message" {
+  puff_init "myproject"
+
+  local other_dir
+  other_dir="$(mktemp -d)"
+  cd "$other_dir"
+  run puff link myproject
+  assert_success
+  assert_output_contains "no managed files"
+
+  rm -rf "$other_dir"
+}
+
+@test "link: multiple files are all linked" {
+  puff_init "myproject"
+  echo "a=1" >.env
+  echo "b=2" >.secrets
+  puff add .env .secrets
+
+  local other_dir
+  other_dir="$(mktemp -d)"
+  cd "$other_dir"
+  run puff link myproject
+  assert_success
+  assert_symlink "$other_dir/.env"
+  assert_symlink "$other_dir/.secrets"
+  assert_file_content "$other_dir/.env" "a=1"
+  assert_file_content "$other_dir/.secrets" "b=2"
+
+  rm -rf "$other_dir"
+}


### PR DESCRIPTION
Adds a feature that allows you to create kind of clones of your project. Useful for git worktrees and such. Links are temporary, created once and not managed by puff again. You can relink though.

Solves #13 